### PR TITLE
Remove extra `.-current` call for `use-ref` hook-view

### DIFF
--- a/src/cljs_react_devtools/core.cljs
+++ b/src/cljs_react_devtools/core.cljs
@@ -448,7 +448,7 @@
                             ($ data-view {:data (vec (.-deps hook)) :style {:margin 0}})))
 
                       "use-ref"
-                      ($ data-view {:data (.. hook -current -current) :style {:margin 0}})
+                      ($ data-view {:data (.. hook -current) :style {:margin 0}})
 
                       ($ data-view {:data hook :style {:margin 0}}))))))
            hooks)))))


### PR DESCRIPTION
Fix for https://github.com/roman01la/cljs-react-devtools/issues/4