### PR TITLE
Revert "Remove extra `.-current` call for `use-ref` hook-view"

### DIFF
--- a/src/cljs_react_devtools/core.cljs
+++ b/src/cljs_react_devtools/core.cljs
@@ -448,7 +448,7 @@
                             ($ data-view {:data (vec (.-deps hook)) :style {:margin 0}})))
 
                       "use-ref"
-                      ($ data-view {:data (.. hook -current) :style {:margin 0}})
+                      ($ data-view {:data (.. hook -current -current) :style {:margin 0}})
 
                       ($ data-view {:data hook :style {:margin 0}}))))))
            hooks)))))


### PR DESCRIPTION
Reverts roman01la/cljs-react-devtools#5

I've double checked and this seem to be an incorrect fix. `(.. ref -current -current)` is valid. The other case when it crashes is probably different. @ovistoica do you have a repro for it?

<img width="312" alt="Screenshot 2024-05-31 at 16 44 22" src="https://github.com/roman01la/cljs-react-devtools/assets/1355501/11afffe0-3d0b-430e-8a85-f8296627ee75">
